### PR TITLE
Remove `function.constant()` usages

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -13,7 +13,7 @@ gleam = ">= 0.33.0"
 [dependencies]
 gleam_stdlib = ">= 0.34.0 and < 2.0.0"
 birl = ">= 1.7.0 and < 2.0.0"
-gleam_json = "> 1.0.0 and < 2.0.0"
 
 [dev-dependencies]
+gleam_json = "> 1.0.0 and < 2.0.0"
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/gleam.toml
+++ b/gleam.toml
@@ -11,9 +11,9 @@ links = [
 gleam = ">= 0.33.0"
 
 [dependencies]
-gleam_stdlib = "~> 0.34"
-birl = "~> 1.0"
+gleam_stdlib = ">= 0.34.0 and < 2.0.0"
+birl = ">= 1.7.0 and < 2.0.0"
+gleam_json = "> 1.0.0 and < 2.0.0"
 
 [dev-dependencies]
-gleeunit = "~> 1.0"
-gleam_json = "~> 0.7"
+gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,16 +2,16 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "birl", version = "1.3.2", build_tools = ["gleam"], requirements = ["ranger", "gleam_stdlib"], otp_app = "birl", source = "hex", outer_checksum = "82C09FD40A7273E530E545D997265699C7F748360FC860BD07CD352E0BD049D4" },
-  { name = "gleam_json", version = "0.7.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "thoas"], otp_app = "gleam_json", source = "hex", outer_checksum = "CB405BD93A8828BCD870463DE29375E7B2D252D9D124C109E5B618AAC00B86FC" },
-  { name = "gleam_stdlib", version = "0.34.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "1FB8454D2991E9B4C0C804544D8A9AD0F6184725E20D63C3155F0AEB4230B016" },
-  { name = "gleeunit", version = "1.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "D364C87AFEB26BDB4FB8A5ABDE67D635DC9FA52D6AB68416044C35B096C6882D" },
-  { name = "ranger", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "ranger", source = "hex", outer_checksum = "28E615AE7590ED922AF1510DDF606A2ECBBC2A9609AF36D412EDC925F06DFD20" },
-  { name = "thoas", version = "0.4.1", build_tools = ["rebar3"], requirements = [], otp_app = "thoas", source = "hex", outer_checksum = "4918D50026C073C4AB1388437132C77A6F6F7C8AC43C60C13758CC0ADCE2134E" },
+  { name = "birl", version = "1.7.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "ranger"], otp_app = "birl", source = "hex", outer_checksum = "B1FA529E7BE3FF12CADF32814AB8EC7294E74CEDEE8CC734505707B929A98985" },
+  { name = "gleam_json", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "thoas"], otp_app = "gleam_json", source = "hex", outer_checksum = "9063D14D25406326C0255BDA0021541E797D8A7A12573D849462CAFED459F6EB" },
+  { name = "gleam_stdlib", version = "0.38.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "663CF11861179AF415A625307447775C09404E752FF99A24E2057C835319F1BE" },
+  { name = "gleeunit", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "72CDC3D3F719478F26C4E2C5FED3E657AC81EC14A47D2D2DEBB8693CA3220C3B" },
+  { name = "ranger", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "ranger", source = "hex", outer_checksum = "1566C272B1D141B3BBA38B25CB761EF56E312E79EC0E2DFD4D3C19FB0CC1F98C" },
+  { name = "thoas", version = "1.2.1", build_tools = ["rebar3"], requirements = [], otp_app = "thoas", source = "hex", outer_checksum = "E38697EDFFD6E91BD12CEA41B155115282630075C2A727E7A6B2947F5408B86A" },
 ]
 
 [requirements]
-birl = { version = "~> 1.0" }
-gleam_json = { version = "~> 0.7" }
-gleam_stdlib = { version = "~> 0.34" }
-gleeunit = { version = "~> 1.0" }
+birl = { version = ">= 1.7.0 and < 2.0.0" }
+gleam_json = { version = "> 1.0.0 and < 2.0.0" }
+gleam_stdlib = { version = ">= 0.34.0 and < 2.0.0" }
+gleeunit = { version = ">= 1.0.0 and < 2.0.0" }

--- a/src/gleam/hexpm.gleam
+++ b/src/gleam/hexpm.gleam
@@ -1,9 +1,8 @@
-import gleam/dynamic.{type DecodeError, type Dynamic, DecodeError} as dyn
-import gleam/dict.{type Dict}
-import gleam/option.{type Option, None}
-import gleam/function
-import gleam/result
 import birl.{type Time}
+import gleam/dict.{type Dict}
+import gleam/dynamic.{type DecodeError, type Dynamic, DecodeError} as dyn
+import gleam/option.{type Option, None}
+import gleam/result
 
 /// Information on a package from Hex's `/api/packages` endpoint.
 pub type Package {
@@ -137,7 +136,7 @@ pub fn decode_release(data: Dynamic) -> Result(Release, List(DecodeError)) {
       dyn.any([
         dyn.int,
         // For some unknown reason Hex will return [] when there are no downloads.
-        function.constant(Ok(0)),
+        fn(_) { Ok(0) },
       ]),
     ),
     dyn.field("publisher", dyn.optional(decode_package_owner)),
@@ -168,10 +167,7 @@ fn decode_package_owner(
   dyn.decode3(
     PackageOwner,
     dyn.field("username", dyn.string),
-    dyn.any([
-      dyn.field("email", dyn.optional(dyn.string)),
-      function.constant(Ok(None)),
-    ]),
+    dyn.any([dyn.field("email", dyn.optional(dyn.string)), fn(_) { Ok(None) }]),
     dyn.field("url", dyn.string),
   )(data)
 }

--- a/test/gleam/hexpm_test.gleam
+++ b/test/gleam/hexpm_test.gleam
@@ -1,11 +1,11 @@
-import gleam/json
+import birl.{type Time}
 import gleam/dict
-import gleam/option.{None, Some}
 import gleam/hexpm.{
   Package, PackageMeta, PackageOwner, PackageRelease, Release, ReleaseMeta,
   ReleaseRetirement, Security,
 }
-import birl.{type Time}
+import gleam/json
+import gleam/option.{None, Some}
 import gleeunit/should
 
 pub fn hex_package_decoder_test() {


### PR DESCRIPTION
# Why?
- `function.constant(v)` was deprecated and creates build warnings when used as a dependency

# Note
- Updated dependencies as well, opted to avoid gleam_json 2.0.0 because of the erlang 27.0 requirement